### PR TITLE
Add windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ running it, use the "--dry" option as the very first argument to
 
 To get a reminder of the arguments, use `mmongo --help`.
 
+## Windows
+
+Add the MongoDB `bin` directory to your path. (If you installed with Choco, it's `C:\MongoDB\bin`.) Check by running `where mongo`. 
+
 ## Fork me
 
 https://github.com/skagedal/mmongo

--- a/mmongo.js
+++ b/mmongo.js
@@ -27,6 +27,10 @@ function main() {
   var urlObj = url.parse(mUrl);
   var newArgs = buildArgs (args.command, args.commandArgs, urlObj);
 
+  if (process.platform === 'win32') {
+	  args.command.exec += '.bat';
+  }
+
   if (args.dryRun) {
     var fullCommand = shellQuote([args.command.exec].concat(newArgs));
     console.log(fullCommand);
@@ -96,7 +100,14 @@ function getMeteorMongoUrl(site) {
   if (site)
     args.push(site);
 
-  var ret = child_process.spawnSync('meteor', args);
+  var ret;
+  
+  if (process.platform === 'win32') {
+    ret = child_process.spawnSync('meteor.bat', args);
+  } else {
+    ret = child_process.spawnSync('meteor', args);
+  }
+  
   if (ret.status != 0) {
     var exc = new MeteorMongoException(ret.status, ret.stderr);
     exc.status = ret.status;

--- a/mmongo.js
+++ b/mmongo.js
@@ -27,10 +27,6 @@ function main() {
   var urlObj = url.parse(mUrl);
   var newArgs = buildArgs (args.command, args.commandArgs, urlObj);
 
-  if (process.platform === 'win32') {
-	  args.command.exec += '.bat';
-  }
-
   if (args.dryRun) {
     var fullCommand = shellQuote([args.command.exec].concat(newArgs));
     console.log(fullCommand);


### PR DESCRIPTION
Adds .bat to spawn commands to allow Windows to resolve `meteor` and `mongo` commands.

I think this should fix #2. This is based on [this fix to gulp](https://github.com/laurentdesmet/gulp-nodemon/commit/b11ca2647847ce112fe76b9b69a8e816544156b2), which had a similar problem on Windows.
